### PR TITLE
Use a clearer version of the first paper

### DIFF
--- a/papers.md
+++ b/papers.md
@@ -3,6 +3,7 @@
 This is not a fixed list, welcome to extend!
 
 * [An inverse of the evaluation functional for typed lambda-calculus](https://www.mathematik.uni-muenchen.de/~schwicht/papers/lics91/paper.pdf). U Berger and H Schwichtenberg (1991)
+  + ^ Is a digital version with broken references. There's also a [scanned version that has correct references but lacks copy quality](https://epub.ub.uni-muenchen.de/4261/1/4261.pdf).
 * [From semantics to rules: A machine assisted analysis](https://link.springer.com/content/pdf/10.1007/BFb0049326.pdf). C Coquand (1993)
 * [Intuitionistic model constructions and normalization proofs](https://www.cambridge.org/core/journals/mathematical-structures-in-computer-science/article/intuitionistic-model-constructions-and-normalization-proofs/15AE4B790FF9E4B1998CE92054DBD3CF). T Coquand and P Dybjer (1993, 1997)
 * [Categorical reconstruction of a reduction free normalization proof](https://link.springer.com/content/pdf/10.1007/3-540-60164-3_27.pdf). T Altenkirch, M Hofmann, and T Streicher (1995)

--- a/papers.md
+++ b/papers.md
@@ -2,7 +2,7 @@
 
 This is not a fixed list, welcome to extend!
 
-* [An inverse of the evaluation functional for typed lambda-calculus](https://epub.ub.uni-muenchen.de/4261/1/4261.pdf). U Berger and H Schwichtenberg (1991)
+* [An inverse of the evaluation functional for typed lambda-calculus](https://www.mathematik.uni-muenchen.de/~schwicht/papers/lics91/paper.pdf). U Berger and H Schwichtenberg (1991)
 * [From semantics to rules: A machine assisted analysis](https://link.springer.com/content/pdf/10.1007/BFb0049326.pdf). C Coquand (1993)
 * [Intuitionistic model constructions and normalization proofs](https://www.cambridge.org/core/journals/mathematical-structures-in-computer-science/article/intuitionistic-model-constructions-and-normalization-proofs/15AE4B790FF9E4B1998CE92054DBD3CF). T Coquand and P Dybjer (1993, 1997)
 * [Categorical reconstruction of a reduction free normalization proof](https://link.springer.com/content/pdf/10.1007/3-540-60164-3_27.pdf). T Altenkirch, M Hofmann, and T Streicher (1995)


### PR DESCRIPTION
Both versions are hosted by `uni-muenchen.de` but the updated one is a digital copy (which I feel is a bit easier to read).